### PR TITLE
New MMAL headers for binding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,6 @@ macro_rules! mmal_fourcc {
     }
 }
 
+pub const MMAL_ENCODING_H264: c_uint = mmal_fourcc!('H','2','6','4');
 pub const MMAL_ENCODING_I420: c_uint = mmal_fourcc!('I','4','2','0');
 pub const MMAL_ENCODING_OPAQUE: c_uint = mmal_fourcc!('O','P','Q','V');

--- a/vendor/include/wrapper.h
+++ b/vendor/include/wrapper.h
@@ -1,10 +1,13 @@
 #include <bcm_host.h>
-#include <interface/vcos/vcos.h>
-
 #include <interface/mmal/mmal.h>
 #include <interface/mmal/mmal_buffer.h>
+#include <interface/mmal/mmal_encodings.h>
+#include <interface/mmal/mmal_events.h>
 #include <interface/mmal/mmal_parameters_camera.h>
 #include <interface/mmal/util/mmal_connection.h>
 #include <interface/mmal/util/mmal_default_components.h>
 #include <interface/mmal/util/mmal_util.h>
 #include <interface/mmal/util/mmal_util_params.h>
+#include <interface/mmal/vc/mmal_vc_api.h>
+#include <interface/vcos/vcos.h>
+#include <interface/vcos/vcos_types.h>


### PR DESCRIPTION
### Summary

Adds a new constant `MMAL_ENCODING_H264`, and headers:

- `<interface/mmal/mmal_encodings.h>`
- `<interface/mmal/mmal_events.h>`
- `<interface/mmal/vc/mmal_vc_api.h>`
- `<interface/vcos/vcos_types.h>`